### PR TITLE
State required osm2pgsql version

### DIFF
--- a/INSTALL-de.md
+++ b/INSTALL-de.md
@@ -12,7 +12,7 @@ localization only changes to Openstreetmap Carto.
 Master branch will do localization and other visual German style changes.
 
 For database import the localization code from
-https://github.com/giggls/osml10n and the new Flex backend of osm2pgsql is
+https://github.com/giggls/osml10n and osm2pgsql 1.7.0 or higher is
 required.
 
 The import command looks like this:


### PR DESCRIPTION
A new osm2pgsql version has been [released](https://github.com/openstreetmap/osm2pgsql/releases/tag/1.7.0) with the required bbox functionality for relations. This replaces the rather vague requirement with an explicit version baseline.