### PR TITLE
Remove -G option in install instructions

### DIFF
--- a/INSTALL-de.md
+++ b/INSTALL-de.md
@@ -21,7 +21,7 @@ required.
 The import command looks like this:
 
 ```
-osm2pgsql -G -O flex -d osm -S openstreetmap-carto-hstore-only-l10n.lua planet-latest.osm.pbf
+osm2pgsql -O flex -d osm -S openstreetmap-carto-hstore-only-l10n.lua planet-latest.osm.pbf
 ```
 
 See osml10n installation instructions for details.


### PR DESCRIPTION
The `-G` option doesn't do anything when flex mode is used.