### PR TITLE
Add support for additional display of alternative/old names

### DIFF
--- a/openstreetmap-carto-flex-l10n.lua
+++ b/openstreetmap-carto-flex-l10n.lua
@@ -640,6 +640,32 @@ local function gen_l10n_name(object, islinear, iscountry)
         return country_string
     else
         names = osml10n.get_names_from_tags(object.id, object.tags, localized_name_last, is_street, L10NLANG, { object:get_bbox() })
+
+        local secondary_local_name = nil
+        local alt_local_name = object.tags['alt_name:' .. L10NLANG]
+        local old_local_name = object.tags['old_name:' .. L10NLANG]
+        if (alt_local_name ~= nil and alt_local_name ~= names[1] and alt_local_name ~= names[2]) then
+            secondary_local_name = alt_local_name
+        elseif (old_local_name ~= nil and old_local_name ~= names[1] and old_local_name ~= names[2]) then
+            secondary_local_name = old_local_name
+        end
+        if (secondary_local_name ~= nil)
+            local idxl, idxn
+            if localized_name_last then
+                idxl = 2 idxn = 1
+            else
+                idxl = 1 idxn = 2
+            end
+            if (names[1] == '') then
+                names[1] = names[2]
+                names[2] = '(' .. secondary_local_name .. ')'
+            elseif (names[idxl] ~= '') then
+                names[idxl] = names[idxl] .. ' (' .. secondary_local_name .. ')'
+            else
+                names[idxl] = '(' .. secondary_local_name .. ')'
+            end
+        end
+
         return l10n_arr_to_str(names, delim)
     end
 end

--- a/taginfo.json
+++ b/taginfo.json
@@ -187,6 +187,22 @@
             ]
         },
         {
+            "key": "alt_name:de",
+            "object_types": [
+                "node",
+                "way",
+                "area"
+            ]
+        },
+        {
+            "key": "old_name:de",
+            "object_types": [
+                "node",
+                "way",
+                "area"
+            ]
+        },
+        {
             "key": "int_name",
             "object_types": [
                 "node",


### PR DESCRIPTION
Hello,

While `name:xx` key is supposed to hold the information for a common and contemporary name for an object in a language `xx`, it is a long-recurring issue that German-speaking mappers seem to try to fill-in the `name:de` key in every case whenever a German-language name for a place has ever existed. The reason most often cited for such changes is that "the name was wrong/missing from the German maps", so that brought me here.

Currently, the map at OSM DE seeks to display both local and German names. And that works pretty well. But there are several issues with the naive approach:
* If a localised name fell out of common use, or was replaced by another one, it should not be put not into `name:de`. But then it gets not rendered on "the German map". This leads to cyclic edit warring between various groups of mappers.
* Another issue is that, since (sadly) most of the `name:de` names are only of historic value, it tempts to add even more historic names for even more places, which have their German name "missing" from the German map. The most jarring example I've stumbled upon was `name:de=Resche` added to Rzeszów, a name which was apparently last mentioned in the year 1438
* The use of `name:de` for little-known outdated names, fueled by OSM DE rendering, makes things even worse for other maps, where `name:de` is not an additional, but the only name being rendered (like, for example, the MapTiler OMT style, featured on osm.org)

I think one of the possible solutions to break this impasse is to allow for the display of the alternative/old German name on the German map, especially if the `name:de` is missing or equal to the value of `name`. Therefore, the users of the German map would get their desired names rendered, even with such tagging that is no longer bending the rules or breaking other maps as a result.

Important remark here. The code in this PR was not tested at all, and it's been ages since I've last written any Lua. So it might not work. But I thought that nevertheless it would make for a better discussion starting point than just opening an issue would, as it gives an insight to what I think a possible solution could look like.

So, here are a few examples of what my intention to change the name building process was:
* `name=Львів` + `name:de=Lwiw` + `alt_name:de=Lemberg` should get rendered as  `Львів\nLwiw (Lemberg)`. Currently, with such tagging, only `Львів\nLwiw` would get displayed, where "Lwiw" could get interpreted by some as a mere transliteration, and therefore as a "German name missing", which temps to change the `name:de` to `Lemberg` (which we don't want, since "Lwiw" seems to be the more common & contemporary German name)
* `name=Bratislava` + `name:de=Bratislava` + `old_name:de=Preßburg` + `capital=yes` should get rendered as `Bratislava\n(Preßburg)`. Currently, with such tagging, only `Bratislava` would get displayed, which could be interpreted by some as a "German name missing", which temps to change the `name:de` to `Pressburg` (which we don't want, since "Bratislava" seems to be the more common & contemporary German name)

(If my remarks on the common usage of the German names for the cities I've mentioned above as the examples are not correct, then I'm sorry. Yet, the situation is similar for most of the thousands of towns and villages across the Central-Eastern Europe, so the issue is real)

Hope you find this helpful


